### PR TITLE
fix: ensure that the eks-ondemand and eks-ondemand-cn roles are made unique.

### DIFF
--- a/clusters/eks-ondemand-cn/main.tf
+++ b/clusters/eks-ondemand-cn/main.tf
@@ -112,7 +112,7 @@ module "eks" {
     # One access entry with a policy associated
     ex-single-test = {
       kubernetes_groups = []
-      principal_arn     = aws_iam_role.this["single-test"].arn
+      principal_arn     = aws_iam_role.this["single-test-${local.region}-${local.name}"].arn
 
       policy_associations = {
         single = {
@@ -128,7 +128,7 @@ module "eks" {
     # Example of adding multiple policies to a single access entry
     ex-multiple-test = {
       kubernetes_groups = []
-      principal_arn     = aws_iam_role.this["multiple-test"].arn
+      principal_arn     = aws_iam_role.this["multiple-test-${local.region}-${local.name}"].arn
 
       policy_associations = {
         ex-one = {
@@ -261,7 +261,7 @@ data "aws_ami" "eks_default" {
 }
 
 resource "aws_iam_role" "this" {
-  for_each = toset(["single-test", "multiple-test"])
+  for_each = toset(["single-test-${local.region}-${local.name}", "multiple-test-${local.region}-${local.name}"])
 
   name = "ex-${each.key}"
 

--- a/clusters/eks-ondemand/main.tf
+++ b/clusters/eks-ondemand/main.tf
@@ -112,7 +112,7 @@ module "eks" {
     # One access entry with a policy associated
     ex-single-test = {
       kubernetes_groups = []
-      principal_arn     = aws_iam_role.this["single-test"].arn
+      principal_arn     = aws_iam_role.this["single-test-${local.region}-${local.name}"].arn
 
       policy_associations = {
         single = {
@@ -128,7 +128,7 @@ module "eks" {
     # Example of adding multiple policies to a single access entry
     ex-multiple-test = {
       kubernetes_groups = []
-      principal_arn     = aws_iam_role.this["multiple-test"].arn
+      principal_arn     = aws_iam_role.this["multiple-test-${local.region}-${local.name}"].arn
 
       policy_associations = {
         ex-one = {
@@ -261,7 +261,7 @@ data "aws_ami" "eks_default" {
 }
 
 resource "aws_iam_role" "this" {
-  for_each = toset(["single-test", "multiple-test"])
+  for_each = toset(["single-test-${local.region}-${local.name}", "multiple-test-${local.region}-${local.name}"])
 
   name = "ex-${each.key}"
 


### PR DESCRIPTION
[fix: ensure that the eks-ondemand and eks-ondemand-cn roles are made unique.](https://github.com/cloudpilot-ai/examples/pull/21/commits/b4224ba9394b57644c7e8f8acd7061113d8d7c78)

Fixes #20.

Sync with #20.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* clusters/eks-ondemand-cn/main.tf
* clusters/eks-ondemand/main.tf

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```